### PR TITLE
Fix handbook context extraction

### DIFF
--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -108,7 +108,7 @@ export default async function handler(req, res) {
           .slice(0, 3);
 
         relevantContext = topMatches
-          .map(match => `관련 정보: ${match.text}`)
+          .map(match => `관련 정보: ${match.content}`)
           .join('\n\n');
       }
     } catch (embeddingError) {


### PR DESCRIPTION
## Summary
- use `match.content` when building `relevantContext`

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6881a6c7d09c83229f11c3937f7fb974